### PR TITLE
fix ImportError: ensure Jinja2<3.1

### DIFF
--- a/report/requirements.txt
+++ b/report/requirements.txt
@@ -3,3 +3,4 @@ sphinxcontrib-bibtex<2.0.0
 matplotlib
 numpy
 sklearn
+jinja2<3.1


### PR DESCRIPTION
**fixes**: [`ImportError: cannot import name 'environmentfilter' from 'jinja2'`](https://github.com/readthedocs/readthedocs.org/issues/9038) due to newer versions of Jinja
**TODO**: update `templates/report_config.zip` to match